### PR TITLE
Extend several timeouts for very large files

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,6 +5,7 @@ location YNH_WWW_LOCATION {
   }
   client_max_body_size 10G;
   client_body_timeout 30m;
+  proxy_read_timeout 30m;
   index index.php;
   try_files $uri $uri/ index.php;
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -4,6 +4,7 @@ location YNH_WWW_LOCATION {
     rewrite ^ https://$server_name$request_uri? permanent;
   }
   client_max_body_size 10G;
+  client_body_timeout 30m;
   index index.php;
   try_files $uri $uri/ index.php;
 


### PR DESCRIPTION
Extend client_body_timeout as advised on Jirafeau website: https://gitlab.com/mojo42/Jirafeau#my-downloads-are-incomplete-or-my-uploads-fails
(client_header_timeout can't be set at this configuration level)

Also extend proxy_read_timeout as advised here: http://howtounix.info/howto/110-connection-timed-out-error-in-nginx

Fix proposal for bug #507 (https://dev.yunohost.org/issues/507)