### PR TITLE
Remove ini file for php

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -373,3 +373,6 @@ catch_workers_output = yes
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+php_admin_value[upload_max_filesize] = 10G
+php_admin_value[post_max_size] = 10G

--- a/conf/php-fpm.ini
+++ b/conf/php-fpm.ini
@@ -1,3 +1,0 @@
-upload_max_filesize=10G
-post_max_size=10G
-; max_execution_time=60

--- a/scripts/backup
+++ b/scripts/backup
@@ -55,4 +55,3 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
-ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"

--- a/scripts/restore
+++ b/scripts/restore
@@ -65,7 +65,6 @@ ynh_system_user_create $app
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
-ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # SPECIFIC RESTORE


### PR DESCRIPTION
## Problem
- *Have a look to https://github.com/YunoHost-Apps/nextcloud_ynh/issues/138 for more information*

## Solution
- *Get rid of the ini file and merge its content into the pool file.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Josué
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/jirafeau_ynh%20remove_php_ini%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/jirafeau_ynh%20remove_php_ini%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.