### PR TITLE
Do not output upload password in logs (fix #60)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -23,7 +23,9 @@ ynh_abort_if_errors
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 admin_user=$YNH_APP_ARG_ADMIN_USER
+ynh_print_OFF
 upload_password=$YNH_APP_ARG_UPLOAD_PASSWORD
+ynh_print_ON
 is_public=$YNH_APP_ARG_IS_PUBLIC
 
 app=$YNH_APP_INSTANCE_NAME
@@ -94,6 +96,7 @@ jirafeauconfigfile="$final_path/lib/config.local.php"
 cp "../conf/config.local.php" "$jirafeauconfigfile"
 
 # Set and save upload password, allowing an empty one
+ynh_print_OFF
 if [ -z "$upload_password" ]
 then
 	ynh_replace_string --match_string="__YNH_UPLOAD_PASSWORD__" --replace_string="" --target_file="$jirafeauconfigfile"
@@ -102,6 +105,7 @@ else
 	ynh_replace_string --match_string="__YNH_UPLOAD_PASSWORD__" --replace_string="'$upload_password'" --target_file="$jirafeauconfigfile"
 	ynh_app_setting_set --app=$app --key=upload_password --value="$upload_password"
 fi
+ynh_print_ON
 
 #=================================================
 # CONFIGURE JIRAFEAU

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -21,7 +21,9 @@ path_url=$(ynh_app_setting_get --app=$app --key=path)
 admin_user=$(ynh_app_setting_get --app=$app --key=admin_user)
 is_public=$(ynh_app_setting_get --app=$app --key=is_public)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+ynh_print_OFF
 upload_password=$(ynh_app_setting_get --app=$app --key=upload_password)
+ynh_print_ON
 
 #=================================================
 # CHECK VERSION
@@ -121,6 +123,7 @@ ynh_backup_if_checksum_is_different --file="$final_path/lib/config.local.php"
 cp "../conf/config.local.php" "$final_path/lib/config.local.php"
 
 # Set and save upload password, allowing an empty one
+ynh_print_OFF
 if [ -z "$upload_password" ]
 then
     ynh_replace_string --match_string="__YNH_UPLOAD_PASSWORD__" --replace_string="" --target_file="$jirafeauconfigfile"
@@ -129,6 +132,7 @@ else
     ynh_replace_string --match_string="__YNH_UPLOAD_PASSWORD__" --replace_string="'$upload_password'" --target_file="$jirafeauconfigfile"
 	ynh_app_setting_set --app=$app --key=upload_password --value="$upload_password"
 fi
+ynh_print_ON
 
 #=================================================
 # CONFIGURE JIRAFEAU


### PR DESCRIPTION
## Problem
- Fix issue #60: upload password leaking

## Solution
- Toggling logs before/after upload password usage

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/jirafeau_ynh%20PR61/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/jirafeau_ynh%20PR61/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
