### PR TITLE
fix regexp for change_url script

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -80,7 +80,7 @@ fi
 #=================================================
 
 # Change domain name in parameters.yml
-ynh_replace_string --match_string="\$cfg['web_root'] = .*" --replace_string="\$cfg['web_root'] = 'https://' . '$new_domain' . '${new_path%/}' . '/';" --target_file="$final_path/lib/config.local.php"
+ynh_replace_string --match_string="\$cfg\['web_root'\] = .*" --replace_string="\$cfg['web_root'] = 'https://' . '$new_domain' . '${new_path%/}' . '/';" --target_file="$final_path/lib/config.local.php"
 
 #=================================================
 # GENERIC FINALISATION


### PR DESCRIPTION
## Problem
- *regexp was not working, needed to escape squared brackets.*

## Solution
- *change regexp* : Fix https://github.com/YunoHost-Apps/jirafeau_ynh/issues/77

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/jirafeau_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/jirafeau_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
