### PR TITLE
PHP shouldn't allow `array(foobar)` to work if foobar is undefined...

### DIFF
--- a/conf/config.local.php
+++ b/conf/config.local.php
@@ -74,7 +74,7 @@ $cfg['link_name_length'] = 8;
  * $cfg['upload_password'] = array('psw1');         // One password
  * $cfg['upload_password'] = array('psw1', 'psw2'); // Two passwords
  */
-$cfg['upload_password'] = array(__UPLOAD_PASSWORD__);
+$cfg['upload_password'] = array('__UPLOAD_PASSWORD__');
 
 /* List of IP allowed to upload a file.
  * If the list is empty, then there is no upload restriction based on IP.


### PR DESCRIPTION
## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
